### PR TITLE
feat: add simple RDMA communication support

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,6 +27,14 @@ name = "routeguide-client"
 path = "src/routeguide/client.rs"
 
 [[bin]]
+name = "routeguide-rdma-server"
+path = "src/routeguide_rdma/server.rs"
+
+[[bin]]
+name = "routeguide-rdma-client"
+path = "src/routeguide_rdma/client.rs"
+
+[[bin]]
 name = "authentication-client"
 path = "src/authentication/client.rs"
 

--- a/examples/src/json-codec/common.rs
+++ b/examples/src/json-codec/common.rs
@@ -30,6 +30,14 @@ impl<T: serde::Serialize> Encoder for JsonEncoder<T> {
     fn encode(&mut self, item: Self::Item, buf: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
         serde_json::to_writer(buf.writer(), &item).map_err(|e| Status::internal(e.to_string()))
     }
+
+    fn encode_into_slice(
+        &mut self,
+        _item: Self::Item,
+        _buf: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]
@@ -40,6 +48,16 @@ impl<U: serde::de::DeserializeOwned> Decoder for JsonDecoder<U> {
     type Error = Status;
 
     fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        if !buf.has_remaining() {
+            return Ok(None);
+        }
+
+        let item: Self::Item =
+            serde_json::from_reader(buf.reader()).map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Some(item))
+    }
+
+    fn decode_from_slice(&mut self, buf: &[u8]) -> Result<Option<Self::Item>, Self::Error> {
         if !buf.has_remaining() {
             return Ok(None);
         }

--- a/examples/src/routeguide_rdma/client.rs
+++ b/examples/src/routeguide_rdma/client.rs
@@ -1,0 +1,126 @@
+use std::error::Error;
+use std::time::Duration;
+
+use futures::stream;
+use rand::rngs::ThreadRng;
+use rand::Rng;
+use tokio::time;
+use tonic::transport::RdmaChannel;
+use tonic::Request;
+
+use routeguide::route_guide_client::RouteGuideClient;
+use routeguide::{Point, Rectangle, RouteNote};
+
+pub mod routeguide {
+    tonic::include_proto!("routeguide");
+}
+
+async fn print_features(client: &mut RouteGuideClient<RdmaChannel>) -> Result<(), Box<dyn Error>> {
+    let rectangle = Rectangle {
+        lo: Some(Point {
+            latitude: 400_000_000,
+            longitude: -750_000_000,
+        }),
+        hi: Some(Point {
+            latitude: 420_000_000,
+            longitude: -730_000_000,
+        }),
+    };
+
+    let mut stream = client
+        .list_features(Request::new(rectangle))
+        .await?
+        .into_inner();
+
+    while let Some(feature) = stream.message().await? {
+        println!("NOTE = {:?}", feature);
+    }
+
+    Ok(())
+}
+
+async fn run_record_route(client: &mut RouteGuideClient<RdmaChannel>) -> Result<(), Box<dyn Error>> {
+    let mut rng = rand::thread_rng();
+    let point_count: i32 = rng.gen_range(2..100);
+
+    let mut points = vec![];
+    for _ in 0..=point_count {
+        points.push(random_point(&mut rng))
+    }
+
+    println!("Traversing {} points", points.len());
+    let request = Request::new(stream::iter(points));
+
+    match client.record_route(request).await {
+        Ok(response) => println!("SUMMARY: {:?}", response.into_inner()),
+        Err(e) => println!("something went wrong: {:?}", e),
+    }
+
+    Ok(())
+}
+
+async fn run_route_chat(client: &mut RouteGuideClient<RdmaChannel>) -> Result<(), Box<dyn Error>> {
+    let start = time::Instant::now();
+
+    let outbound = async_stream::stream! {
+        let mut interval = time::interval(Duration::from_secs(1));
+
+        loop {
+            let time = interval.tick().await;
+            let elapsed = time.duration_since(start);
+            let note = RouteNote {
+                location: Some(Point {
+                    latitude: 409146138 + elapsed.as_secs() as i32,
+                    longitude: -746188906,
+                }),
+                message: format!("at {:?}", elapsed),
+            };
+
+            yield note;
+        }
+    };
+
+    let response = client.route_chat(Request::new(outbound)).await?;
+    let mut inbound = response.into_inner();
+
+    while let Some(note) = inbound.message().await? {
+        println!("NOTE = {:?}", note);
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = RouteGuideClient::connect_rdma("[::1]:10001").await?;
+    println!("rdma conn established!");
+
+    println!("*** SIMPLE RPC ***");
+    let response = client
+        .get_feature(Request::new(Point {
+            latitude: 409_146_138,
+            longitude: -746_188_906,
+        }))
+        .await?;
+    println!("RESPONSE = {:?}", response);
+
+    println!("\n*** SERVER STREAMING ***");
+    print_features(&mut client).await?;
+
+    println!("\n*** CLIENT STREAMING ***");
+    run_record_route(&mut client).await?;
+
+    println!("\n*** BIDIRECTIONAL STREAMING ***");
+    run_route_chat(&mut client).await?;
+
+    Ok(())
+}
+
+fn random_point(rng: &mut ThreadRng) -> Point {
+    let latitude = (rng.gen_range(0..180) - 90) * 10_000_000;
+    let longitude = (rng.gen_range(0..360) - 180) * 10_000_000;
+    Point {
+        latitude,
+        longitude,
+    }
+}

--- a/examples/src/routeguide_rdma/client.rs
+++ b/examples/src/routeguide_rdma/client.rs
@@ -28,7 +28,7 @@ async fn print_features(client: &mut RouteGuideClient<RdmaChannel>) -> Result<()
     };
 
     let mut stream = client
-        .list_features(Request::new(rectangle))
+        .list_features_rdma(Request::new(rectangle))
         .await?
         .into_inner();
 
@@ -51,7 +51,7 @@ async fn run_record_route(client: &mut RouteGuideClient<RdmaChannel>) -> Result<
     println!("Traversing {} points", points.len());
     let request = Request::new(stream::iter(points));
 
-    match client.record_route(request).await {
+    match client.record_route_rdma(request).await {
         Ok(response) => println!("SUMMARY: {:?}", response.into_inner()),
         Err(e) => println!("something went wrong: {:?}", e),
     }
@@ -80,7 +80,7 @@ async fn run_route_chat(client: &mut RouteGuideClient<RdmaChannel>) -> Result<()
         }
     };
 
-    let response = client.route_chat(Request::new(outbound)).await?;
+    let response = client.route_chat_rdma(Request::new(outbound)).await?;
     let mut inbound = response.into_inner();
 
     while let Some(note) = inbound.message().await? {
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("*** SIMPLE RPC ***");
     let response = client
-        .get_feature(Request::new(Point {
+        .get_feature_rdma(Request::new(Point {
             latitude: 409_146_138,
             longitude: -746_188_906,
         }))

--- a/examples/src/routeguide_rdma/data.rs
+++ b/examples/src/routeguide_rdma/data.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+use std::fs::File;
+
+#[derive(Debug, Deserialize)]
+struct Feature {
+    location: Location,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Location {
+    latitude: i32,
+    longitude: i32,
+}
+
+#[allow(dead_code)]
+pub fn load() -> Vec<crate::routeguide::Feature> {
+    let file = File::open("examples/data/route_guide_db.json").expect("failed to open data file");
+
+    let decoded: Vec<Feature> =
+        serde_json::from_reader(&file).expect("failed to deserialize features");
+
+    decoded
+        .into_iter()
+        .map(|feature| crate::routeguide::Feature {
+            name: feature.name,
+            location: Some(crate::routeguide::Point {
+                longitude: feature.location.longitude,
+                latitude: feature.location.latitude,
+            }),
+        })
+        .collect()
+}

--- a/examples/src/routeguide_rdma/server.rs
+++ b/examples/src/routeguide_rdma/server.rs
@@ -149,7 +149,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let svc = RouteGuideServer::new(route_guide);
 
     Server::builder()
-        .add_service(svc)
+        .add_service(svc.clone())
+        .add_service_rdma(svc)
         .serve_with_rdma(addr, rdma_addr)
         .await?;
 

--- a/examples/src/routeguide_rdma/server.rs
+++ b/examples/src/routeguide_rdma/server.rs
@@ -1,0 +1,201 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+use routeguide::route_guide_server::{RouteGuide, RouteGuideServer};
+use routeguide::{Feature, Point, Rectangle, RouteNote, RouteSummary};
+
+pub mod routeguide {
+    tonic::include_proto!("routeguide");
+}
+
+mod data;
+
+#[derive(Debug)]
+pub struct RouteGuideService {
+    features: Arc<Vec<Feature>>,
+}
+
+#[tonic::async_trait]
+impl RouteGuide for RouteGuideService {
+    async fn get_feature(&self, request: Request<Point>) -> Result<Response<Feature>, Status> {
+        println!("GetFeature = {:?}", request);
+
+        for feature in &self.features[..] {
+            if feature.location.as_ref() == Some(request.get_ref()) {
+                return Ok(Response::new(feature.clone()));
+            }
+        }
+
+        Ok(Response::new(Feature::default()))
+    }
+
+    type ListFeaturesStream = ReceiverStream<Result<Feature, Status>>;
+
+    async fn list_features(
+        &self,
+        request: Request<Rectangle>,
+    ) -> Result<Response<Self::ListFeaturesStream>, Status> {
+        println!("ListFeatures = {:?}", request);
+
+        let (tx, rx) = mpsc::channel(4);
+        let features = self.features.clone();
+
+        tokio::spawn(async move {
+            for feature in &features[..] {
+                if in_range(feature.location.as_ref().unwrap(), request.get_ref()) {
+                    println!("  => send {:?}", feature);
+                    tx.send(Ok(feature.clone())).await.unwrap();
+                }
+            }
+
+            println!(" /// done sending");
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn record_route(
+        &self,
+        request: Request<tonic::Streaming<Point>>,
+    ) -> Result<Response<RouteSummary>, Status> {
+        println!("RecordRoute");
+
+        let mut stream = request.into_inner();
+
+        let mut summary = RouteSummary::default();
+        let mut last_point = None;
+        let now = Instant::now();
+
+        while let Some(point) = stream.next().await {
+            let point = point?;
+
+            println!("  ==> Point = {:?}", point);
+
+            // Increment the point count
+            summary.point_count += 1;
+
+            // Find features
+            for feature in &self.features[..] {
+                if feature.location.as_ref() == Some(&point) {
+                    summary.feature_count += 1;
+                }
+            }
+
+            // Calculate the distance
+            if let Some(ref last_point) = last_point {
+                summary.distance += calc_distance(last_point, &point);
+            }
+
+            last_point = Some(point);
+        }
+
+        summary.elapsed_time = now.elapsed().as_secs() as i32;
+
+        Ok(Response::new(summary))
+    }
+
+    type RouteChatStream = Pin<Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + 'static>>;
+
+    async fn route_chat(
+        &self,
+        request: Request<tonic::Streaming<RouteNote>>,
+    ) -> Result<Response<Self::RouteChatStream>, Status> {
+        println!("RouteChat");
+
+        let mut notes = HashMap::new();
+        let mut stream = request.into_inner();
+
+        let output = async_stream::try_stream! {
+            while let Some(note) = stream.next().await {
+                let note = note?;
+
+                let location = note.location.clone().unwrap();
+
+                let location_notes = notes.entry(location).or_insert(vec![]);
+                location_notes.push(note);
+
+                for note in location_notes {
+                    yield note.clone();
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(output) as Self::RouteChatStream))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:10000".parse().unwrap();
+    let rdma_addr = "[::1]:10001".parse().unwrap();
+
+    println!(
+        "RouteGuideServer listening on: {}(HTTP) and {}(RDMA)",
+        addr, rdma_addr
+    );
+
+    let route_guide = RouteGuideService {
+        features: Arc::new(data::load()),
+    };
+
+    let svc = RouteGuideServer::new(route_guide);
+
+    Server::builder()
+        .add_service(svc)
+        .serve_with_rdma(addr, rdma_addr)
+        .await?;
+
+    Ok(())
+}
+
+impl Eq for Point {}
+
+fn in_range(point: &Point, rect: &Rectangle) -> bool {
+    use std::cmp;
+
+    let lo = rect.lo.as_ref().unwrap();
+    let hi = rect.hi.as_ref().unwrap();
+
+    let left = cmp::min(lo.longitude, hi.longitude);
+    let right = cmp::max(lo.longitude, hi.longitude);
+    let top = cmp::max(lo.latitude, hi.latitude);
+    let bottom = cmp::min(lo.latitude, hi.latitude);
+
+    point.longitude >= left
+        && point.longitude <= right
+        && point.latitude >= bottom
+        && point.latitude <= top
+}
+
+/// Calculates the distance between two points using the "haversine" formula.
+/// This code was taken from http://www.movable-type.co.uk/scripts/latlong.html.
+fn calc_distance(p1: &Point, p2: &Point) -> i32 {
+    const CORD_FACTOR: f64 = 1e7;
+    const R: f64 = 6_371_000.0; // meters
+
+    let lat1 = p1.latitude as f64 / CORD_FACTOR;
+    let lat2 = p2.latitude as f64 / CORD_FACTOR;
+    let lng1 = p1.longitude as f64 / CORD_FACTOR;
+    let lng2 = p2.longitude as f64 / CORD_FACTOR;
+
+    let lat_rad1 = lat1.to_radians();
+    let lat_rad2 = lat2.to_radians();
+
+    let delta_lat = (lat2 - lat1).to_radians();
+    let delta_lng = (lng2 - lng1).to_radians();
+
+    let a = (delta_lat / 2f64).sin() * (delta_lat / 2f64).sin()
+        + (lat_rad1).cos() * (lat_rad2).cos() * (delta_lng / 2f64).sin() * (delta_lng / 2f64).sin();
+
+    let c = 2f64 * a.sqrt().atan2((1f64 - a).sqrt());
+
+    (R * c) as i32
+}

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -161,6 +161,34 @@ pub mod health_client {
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
     }
+    impl<T> HealthClient<T>
+    where
+        T: tonic::transport::RdmaService,
+    {
+        pub fn new_rdma(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub async fn check_rdma(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+        ) -> Result<tonic::Response<super::HealthCheckResponse>, tonic::Status> {
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.health.v1.Health/Check",
+            );
+            self.inner.unary_rdma(request.into_request(), path, codec).await
+        }
+        pub async fn watch_rdma(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::HealthCheckResponse>>,
+            tonic::Status,
+        > {
+            todo!()
+        }
+    }
 }
 /// Generated server implementations.
 pub mod health_server {

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -352,6 +352,68 @@ pub mod health_server {
             }
         }
     }
+    impl<T> tonic::codegen::Service<tonic::RdmaRequest> for HealthServer<T>
+    where
+        T: Health,
+    {
+        type Response = tonic::RdmaResponse;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: tonic::RdmaRequest) -> Self::Future {
+            let inner = self.inner.clone();
+            let path = req.path();
+            match path {
+                "/grpc.health.v1.Health/Check" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckSvc<T: Health>(pub Arc<T>);
+                    impl<
+                        T: Health,
+                    > tonic::server::UnaryService<super::HealthCheckRequest>
+                    for CheckSvc<T> {
+                        type Response = super::HealthCheckResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HealthCheckRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).check(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary_rdma(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/grpc.health.v1.Health/Watch" => {
+                    todo!();
+                }
+                _ => todo!(),
+            }
+        }
+    }
     impl<T: Health> Clone for HealthServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -23,7 +23,7 @@ pub mod server_reflection_request {
         FileByFilename(::prost::alloc::string::String),
         /// Find the proto file that declares the given fully-qualified symbol name.
         /// This field should be a fully-qualified symbol name
-        /// (e.g. <package>.<service>\\[.<method>\\] or <package>.<type>).
+        /// (e.g. <package>.<service>\[.<method>\] or <package>.<type>).
         #[prost(string, tag = "4")]
         FileContainingSymbol(::prost::alloc::string::String),
         /// Find the proto file which defines an extension extending the given

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -228,6 +228,26 @@ pub mod server_reflection_client {
             self.inner.streaming(request.into_streaming_request(), path, codec).await
         }
     }
+    impl<T> ServerReflectionClient<T>
+    where
+        T: tonic::transport::RdmaService,
+    {
+        pub fn new_rdma(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub async fn server_reflection_info_rdma(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::ServerReflectionRequest,
+            >,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,
+            tonic::Status,
+        > {
+            todo!()
+        }
+    }
 }
 /// Generated server implementations.
 pub mod server_reflection_server {

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -366,6 +366,30 @@ pub mod server_reflection_server {
             }
         }
     }
+    impl<T> tonic::codegen::Service<tonic::RdmaRequest> for ServerReflectionServer<T>
+    where
+        T: ServerReflection,
+    {
+        type Response = tonic::RdmaResponse;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: tonic::RdmaRequest) -> Self::Future {
+            let inner = self.inner.clone();
+            let path = req.path();
+            match path {
+                "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo" => {
+                    todo!();
+                }
+                _ => todo!(),
+            }
+        }
+    }
     impl<T: ServerReflection> Clone for ServerReflectionServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();

--- a/tonic-types/src/generated/google.rpc.rs
+++ b/tonic-types/src/generated/google.rpc.rs
@@ -7,12 +7,12 @@
 /// [API Design Guide](<https://cloud.google.com/apis/design/errors>).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Status {
-    /// The status code, which should be an enum value of \\[google.rpc.Code\]\[google.rpc.Code\\].
+    /// The status code, which should be an enum value of \[google.rpc.Code][google.rpc.Code\].
     #[prost(int32, tag = "1")]
     pub code: i32,
     /// A developer-facing error message, which should be in English. Any
     /// user-facing error message should be localized and sent in the
-    /// \\[google.rpc.Status.details\]\[google.rpc.Status.details\\] field, or localized by the client.
+    /// \[google.rpc.Status.details][google.rpc.Status.details\] field, or localized by the client.
     #[prost(string, tag = "2")]
     pub message: ::prost::alloc::string::String,
     /// A list of messages that carry the error details.  There is a common set of
@@ -92,36 +92,33 @@ pub mod quota_failure {
 ///
 /// Example of an error when contacting the "pubsub.googleapis.com" API when it
 /// is not enabled:
-///
-/// ```text,json
-///     { "reason": "API_DISABLED"
-///       "domain": "googleapis.com"
-///       "metadata": {
-///         "resource": "projects/123",
-///         "service": "pubsub.googleapis.com"
-///       }
-///     }
+/// ```json
+///      { "reason": "API_DISABLED"
+///        "domain": "googleapis.com"
+///        "metadata": {
+///          "resource": "projects/123",
+///          "service": "pubsub.googleapis.com"
+///        }
+///      }
 /// ```
-///
 /// This response indicates that the pubsub.googleapis.com API is not enabled.
 ///
 /// Example of an error that is returned when attempting to create a Spanner
 /// instance in a region that is out of stock:
-///
-/// ```text,json
-///     { "reason": "STOCKOUT"
-///       "domain": "spanner.googleapis.com",
-///       "metadata": {
-///         "availableRegions": "us-central1,us-east2"
-///       }
-///     }
+/// ```json
+///      { "reason": "STOCKOUT"
+///        "domain": "spanner.googleapis.com",
+///        "metadata": {
+///          "availableRegions": "us-central1,us-east2"
+///        }
+///      }
 /// ```
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ErrorInfo {
     /// The reason of the error. This is a constant value that identifies the
     /// proximate cause of the error. Error reasons are unique within a particular
     /// domain of errors. This should be at most 63 characters and match
-    /// /\\[A-Z0-9\_\\]+/.
+    /// /\[A-Z0-9_\]+/.
     #[prost(string, tag = "1")]
     pub reason: ::prost::alloc::string::String,
     /// The logical grouping to which the "reason" belongs. The error domain
@@ -134,7 +131,7 @@ pub struct ErrorInfo {
     pub domain: ::prost::alloc::string::String,
     /// Additional structured details about this error.
     ///
-    /// Keys should match /\\[a-zA-Z0-9-\_\\]/ and be limited to 64 characters in
+    /// Keys should match /\[a-zA-Z0-9-_\]/ and be limited to 64 characters in
     /// length. When identifying the current value of an exceeded limit, the units
     /// should be contained in the key, not the value.  For example, rather than
     /// {"instanceLimit": "100/request"}, should be returned as,
@@ -226,7 +223,7 @@ pub struct ResourceInfo {
     pub resource_type: ::prost::alloc::string::String,
     /// The name of the resource being accessed.  For example, a shared calendar
     /// name: "example.com_4fghdhgsrgh@group.calendar.google.com", if the current
-    /// error is \\[google.rpc.Code.PERMISSION_DENIED\]\[google.rpc.Code.PERMISSION_DENIED\\].
+    /// error is \[google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED\].
     #[prost(string, tag = "2")]
     pub resource_name: ::prost::alloc::string::String,
     /// The owner of the resource (optional).

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -51,6 +51,7 @@ channel = [
 # harness = false
 
 [dependencies]
+async-rdma = "0.4"
 base64 = "0.13"
 bytes = "1.0"
 futures-core = {version = "0.3", default-features = false}

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -105,6 +105,12 @@ impl Decoder for MockDecoder {
         buf.advance(self.message_size);
         Ok(Some(out))
     }
+
+    fn decode_from_slice(&mut self, mut buf: &[u8]) -> Result<Option<Self::Item>, Self::Error> {
+        let out = Vec::from(buf.chunk());
+        buf.advance(self.message_size);
+        Ok(Some(out))
+    }
 }
 
 fn make_payload(message_length: usize, message_count: usize) -> Bytes {

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -13,7 +13,7 @@ mod prost;
 use crate::Status;
 use std::io;
 
-pub(crate) use self::encode::{encode_client, encode_server};
+pub(crate) use self::encode::{encode_client, encode_rdma, encode_server};
 
 pub use self::buffer::{DecodeBuf, EncodeBuf};
 pub use self::compression::{CompressionEncoding, EnabledCompressionEncodings};

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -59,6 +59,10 @@ pub trait Encoder {
 
     /// Encodes a message into the provided buffer.
     fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error>;
+
+    /// Encodes a message into the provided buffer.
+    fn encode_into_slice(&mut self, item: Self::Item, dst: &mut [u8])
+        -> Result<usize, Self::Error>;
 }
 
 /// Decodes gRPC message types
@@ -75,4 +79,9 @@ pub trait Decoder {
     /// is no need to get the length from the bytes, gRPC framing is handled
     /// for you.
     fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error>;
+
+    /// Decode a message from the buffer.
+    ///
+    /// For RDMA in-situ codec.
+    fn decode_from_slice(&mut self, src: &[u8]) -> Result<Option<Self::Item>, Self::Error>;
 }

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -99,6 +99,7 @@ pub mod transport;
 
 mod extensions;
 mod macros;
+mod rdma;
 mod request;
 mod response;
 mod status;
@@ -112,6 +113,7 @@ pub use async_trait::async_trait;
 #[doc(inline)]
 pub use codec::Streaming;
 pub use extensions::Extensions;
+pub use rdma::{RdmaRequest, RdmaResponse};
 pub use request::{IntoRequest, IntoStreamingRequest, Request};
 pub use response::Response;
 pub use status::{Code, Status};

--- a/tonic/src/rdma.rs
+++ b/tonic/src/rdma.rs
@@ -56,7 +56,6 @@ impl RdmaRequest {
     pub fn body(&self) -> &[u8] {
         let pos = self.separator_index();
         let res = &self.req_mr.as_slice()[pos + 1..self.len];
-        println!("body: {:?}", res);
         res
     }
 }

--- a/tonic/src/rdma.rs
+++ b/tonic/src/rdma.rs
@@ -1,0 +1,76 @@
+use async_rdma::{LocalMr, LocalMrReadAccess, LocalMrWriteAccess};
+
+/// RDMA request. Corresponding to gRPC http::Request
+///
+/// Request content:
+/// {Path of Service}{Blank Space}{Serialied Message}
+#[derive(Debug)]
+pub struct RdmaRequest {
+    req_mr: LocalMr,
+    len: usize,
+    resp_mr: LocalMr,
+}
+
+/// RDMA response. Corresponding to gRPC http::Response
+#[derive(Debug)]
+pub struct RdmaResponse {
+    /// MR where the response message is stored
+    pub resp_mr: LocalMr,
+    /// length of message in MR
+    pub len: usize,
+}
+
+impl RdmaRequest {
+    /// Create a new RdmaRequest
+    pub fn new(req_mr: LocalMr, len: usize, resp_mr: LocalMr) -> Self {
+        Self {
+            req_mr,
+            len,
+            resp_mr,
+        }
+    }
+    /// Get the index of separator(i.e. blank space).
+    fn separator_index(&self) -> usize {
+        self.req_mr
+            .as_slice()
+            .iter()
+            .position(|num| *num == ' ' as u8) // blank space
+            .unwrap()
+    }
+    /// Get service name.
+    pub fn service(&self) -> &str {
+        let pos = self.separator_index();
+        let idx = self.req_mr.as_slice()[0..pos]
+            .iter()
+            .rev()
+            .position(|c| *c == '/' as u8)
+            .unwrap();
+        std::str::from_utf8(&self.req_mr.as_slice()[0..pos - idx - 1]).unwrap()
+    }
+    /// Get path of service function.
+    pub fn path(&self) -> &str {
+        let pos = self.separator_index();
+        std::str::from_utf8(&self.req_mr.as_slice()[0..pos]).unwrap()
+    }
+    /// Get serialized data from MR.
+    pub fn body(&self) -> &[u8] {
+        let pos = self.separator_index();
+        let res = &self.req_mr.as_slice()[pos + 1..self.len];
+        println!("body: {:?}", res);
+        res
+    }
+}
+
+impl RdmaResponse {
+    /// Create RdmaResponse from RdmaRequest.
+    pub fn from_req(req: RdmaRequest) -> Self {
+        Self {
+            resp_mr: req.resp_mr,
+            len: 0,
+        }
+    }
+    /// Get mutable reference of MR slice.
+    pub fn buf(&mut self) -> &mut [u8] {
+        unsafe { self.resp_mr.as_mut_slice_unchecked() }
+    }
+}

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -6,7 +6,7 @@ mod endpoint;
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 mod tls;
 
-pub use rdma_channel::RdmaChannel;
+pub use rdma_channel::{ RdmaChannel, RdmaService };
 pub use endpoint::Endpoint;
 #[cfg(feature = "tls")]
 pub use tls::ClientTlsConfig;

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -1,10 +1,12 @@
 //! Client implementation and builder.
 
+mod rdma_channel;
 mod endpoint;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 mod tls;
 
+pub use rdma_channel::RdmaChannel;
 pub use endpoint::Endpoint;
 #[cfg(feature = "tls")]
 pub use tls::ClientTlsConfig;

--- a/tonic/src/transport/channel/rdma_channel.rs
+++ b/tonic/src/transport/channel/rdma_channel.rs
@@ -1,0 +1,78 @@
+use crate::{
+    body::BoxBody,
+    transport::{self, BoxFuture},
+};
+use async_rdma::{LocalMrReadAccess, LocalMrWriteAccess, Rdma};
+use http::{Request, Response};
+use http_body::Body;
+use std::{alloc::Layout, io, sync::Arc};
+use tokio::net::ToSocketAddrs;
+use tower::Service;
+
+/// A RDMA transport channel
+#[derive(Debug, Clone)]
+pub struct RdmaChannel {
+    rdma: Arc<Rdma>,
+}
+
+const MAX_MSG_LEN: usize = 10240;
+
+impl RdmaChannel {
+    /// Create a new [`RdmaChannel`]
+    pub async fn new<A>(addr: A) -> Result<Self, io::Error>
+    where
+        A: ToSocketAddrs,
+    {
+        // TODO: expose these params to user (create a `RdmaEndpoint` maybe)
+        let rdma = Arc::new(Rdma::connect(addr, 1, 1, MAX_MSG_LEN).await?);
+        Ok(Self { rdma })
+    }
+}
+
+impl Service<Request<BoxBody>> for RdmaChannel {
+    type Response = Response<hyper::Body>;
+    type Error = transport::Error;
+    type Future = BoxFuture<Self::Response, Self::Error>;
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    // TODO: handle error
+    fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
+        let rdma = Arc::clone(&self.rdma);
+        Box::pin(async move {
+            tokio::spawn(rdma_send_req(Arc::clone(&rdma), req));
+
+            let (resp_mr, len) = rdma.receive_with_imm().await.unwrap();
+            let len = len.unwrap() as usize;
+            let resp_vec = resp_mr.as_slice()[0..len].to_vec();
+
+            let body = hyper::Body::from(resp_vec);
+            let resp = http::Response::builder().body(body).unwrap();
+            Ok(resp)
+        })
+    }
+}
+
+async fn rdma_send_req(rdma: Arc<Rdma>, mut req: Request<BoxBody>) {
+    let mut req_header = req.uri().to_string().into_bytes();
+    req_header.push(32u8);
+    let len_header = req_header.len();
+    let mut req_mr = rdma
+        .alloc_local_mr(Layout::new::<[u8; MAX_MSG_LEN]>())
+        .unwrap();
+    req_mr.as_mut_slice()[0..len_header].copy_from_slice(req_header.as_slice());
+
+    let mut len = len_header;
+    while let Some(Ok(bytes)) = req.data().await {
+        let req_body = bytes.to_vec();
+        let len_body = req_body.len();
+        assert!(len + len_body <= MAX_MSG_LEN); // TODO: len > MAX_MSG_LEN
+        req_mr.as_mut_slice()[len..len + len_body].copy_from_slice(req_body.as_slice());
+        len += len_body;
+    }
+    rdma.send_with_imm(&req_mr, len as u32).await.unwrap();
+}

--- a/tonic/src/transport/channel/rdma_channel.rs
+++ b/tonic/src/transport/channel/rdma_channel.rs
@@ -1,13 +1,6 @@
-use crate::{
-    body::BoxBody,
-    transport::{self, BoxFuture},
-};
-use async_rdma::{LocalMrReadAccess, LocalMrWriteAccess, Rdma};
-use http::{Request, Response};
-use http_body::Body;
+use async_rdma::{LocalMr, Rdma};
 use std::{alloc::Layout, io, sync::Arc};
 use tokio::net::ToSocketAddrs;
-use tower::Service;
 
 /// A RDMA transport channel
 #[derive(Debug, Clone)]
@@ -29,50 +22,22 @@ impl RdmaChannel {
     }
 }
 
-impl Service<Request<BoxBody>> for RdmaChannel {
-    type Response = Response<hyper::Body>;
-    type Error = transport::Error;
-    type Future = BoxFuture<Self::Response, Self::Error>;
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    // TODO: handle error
-    fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
-        let rdma = Arc::clone(&self.rdma);
-        Box::pin(async move {
-            tokio::spawn(rdma_send_req(Arc::clone(&rdma), req));
-
-            let (resp_mr, len) = rdma.receive_with_imm().await.unwrap();
-            let len = len.unwrap() as usize;
-            let resp_vec = resp_mr.as_slice()[0..len].to_vec();
-
-            let body = hyper::Body::from(resp_vec);
-            let resp = http::Response::builder().body(body).unwrap();
-            Ok(resp)
-        })
-    }
+/// RDMA service
+#[async_trait::async_trait]
+pub trait RdmaService {
+    /// 
+    fn alloc_mr(&self) -> io::Result<LocalMr>;
+    /// 
+    async fn call(&mut self, req: LocalMr, len: usize) -> (LocalMr, Option<u32>);
 }
 
-async fn rdma_send_req(rdma: Arc<Rdma>, mut req: Request<BoxBody>) {
-    let mut req_header = req.uri().to_string().into_bytes();
-    req_header.push(32u8);
-    let len_header = req_header.len();
-    let mut req_mr = rdma
-        .alloc_local_mr(Layout::new::<[u8; MAX_MSG_LEN]>())
-        .unwrap();
-    req_mr.as_mut_slice()[0..len_header].copy_from_slice(req_header.as_slice());
-
-    let mut len = len_header;
-    while let Some(Ok(bytes)) = req.data().await {
-        let req_body = bytes.to_vec();
-        let len_body = req_body.len();
-        assert!(len + len_body <= MAX_MSG_LEN); // TODO: len > MAX_MSG_LEN
-        req_mr.as_mut_slice()[len..len + len_body].copy_from_slice(req_body.as_slice());
-        len += len_body;
+#[async_trait::async_trait]
+impl RdmaService for RdmaChannel {
+    fn alloc_mr(&self) -> io::Result<LocalMr> {
+        self.rdma.alloc_local_mr(Layout::new::<[u8; MAX_MSG_LEN]>())
     }
-    rdma.send_with_imm(&req_mr, len as u32).await.unwrap();
+    async fn call(&mut self, req: LocalMr, len: usize) -> (LocalMr, Option<u32>) {
+        self.rdma.send_with_imm(&req, len as u32).await.unwrap();
+        self.rdma.receive_with_imm().await.unwrap()
+    }
 }

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -96,7 +96,8 @@ mod tls;
 #[doc(inline)]
 #[cfg(feature = "channel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
-pub use self::channel::{Channel, Endpoint};
+pub use self::channel::{Channel, Endpoint, RdmaChannel};
+pub use tokio::net::ToSocketAddrs;
 pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{NamedService, Server};

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -96,7 +96,7 @@ mod tls;
 #[doc(inline)]
 #[cfg(feature = "channel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
-pub use self::channel::{Channel, Endpoint, RdmaChannel};
+pub use self::channel::{Channel, Endpoint, RdmaChannel, RdmaService};
 pub use tokio::net::ToSocketAddrs;
 pub use self::error::Error;
 #[doc(inline)]

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -9,7 +9,7 @@ mod tls;
 #[cfg(unix)]
 mod unix;
 
-pub use super::service::Routes;
+pub use super::service::{RdmaRoutes, Routes};
 pub use crate::server::NamedService;
 pub use conn::{Connected, TcpConnectInfo};
 #[cfg(feature = "tls")]
@@ -34,8 +34,8 @@ use crate::transport::Error;
 
 use self::recover_error::RecoverError;
 use super::service::{GrpcTimeout, ServerIo};
-use crate::body::BoxBody;
-use async_rdma::{LocalMrReadAccess, LocalMrWriteAccess, Rdma, RdmaBuilder};
+use crate::{body::BoxBody, RdmaRequest, RdmaResponse};
+use async_rdma::{Rdma, RdmaBuilder};
 use bytes::Bytes;
 use futures_core::Stream;
 use futures_util::{future, ready};
@@ -127,6 +127,7 @@ impl Default for Server<Identity> {
 pub struct Router<L = Identity> {
     server: Server<L>,
     routes: Routes,
+    rdma_routes: RdmaRoutes,
 }
 
 impl<S: NamedService, T> NamedService for Either<S, T> {
@@ -354,7 +355,7 @@ impl<L> Server<L> {
         S::Future: Send + 'static,
         L: Clone,
     {
-        Router::new(self.clone(), Routes::new(svc))
+        Router::new(self.clone(), Routes::new(svc), RdmaRoutes::default())
     }
 
     /// Create a router with the optional `S` typed service as the first service.
@@ -376,7 +377,23 @@ impl<L> Server<L> {
         L: Clone,
     {
         let routes = svc.map(Routes::new).unwrap_or_default();
-        Router::new(self.clone(), routes)
+        Router::new(self.clone(), routes, RdmaRoutes::default())
+    }
+
+    /// Create a router with the `S` typed service as the first service.
+    ///
+    ///
+    pub fn add_service_rdma<S>(&mut self, svc: S) -> Router<L>
+    where
+        S: Service<RdmaRequest, Response = RdmaResponse, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+        L: Clone,
+    {
+        Router::new(self.clone(), Routes::default(), RdmaRoutes::new(svc))
     }
 
     /// Set the [Tower] [`Layer`] all services will be wrapped in.
@@ -533,8 +550,12 @@ impl<L> Server<L> {
 }
 
 impl<L> Router<L> {
-    pub(crate) fn new(server: Server<L>, routes: Routes) -> Self {
-        Self { server, routes }
+    pub(crate) fn new(server: Server<L>, routes: Routes, rdma_routes: RdmaRoutes) -> Self {
+        Self {
+            server,
+            routes,
+            rdma_routes,
+        }
     }
 }
 
@@ -574,6 +595,20 @@ impl<L> Router<L> {
         self
     }
 
+    /// Add a new service to this router.
+    pub fn add_service_rdma<S>(mut self, svc: S) -> Self
+    where
+        S: Service<RdmaRequest, Response = RdmaResponse, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        self.rdma_routes = self.rdma_routes.add_service(svc);
+        self
+    }
+
     /// Consume this [`Server`] creating a future that will execute the server
     /// on [tokio]'s default executor.
     ///
@@ -599,7 +634,7 @@ impl<L> Router<L> {
             .await
     }
 
-    /// Listening for HTTP requests from addr 
+    /// Listening for HTTP requests from addr
     /// while listening for RDMA requests from rdma_addr
     pub async fn serve_with_rdma<ResBody>(
         self,
@@ -615,7 +650,7 @@ impl<L> Router<L> {
         ResBody::Error: Into<crate::Error>,
     {
         // let routes_clone = self.routes.clone();
-        tokio::spawn(rdma_serve(rdma_addr, self.routes.clone()));
+        tokio::spawn(rdma_serve(rdma_addr, self.rdma_routes.clone()));
 
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
             .map_err(super::Error::from_source)?;
@@ -880,53 +915,41 @@ where
 }
 
 // TODO: handle this error
-async fn rdma_serve(addr: SocketAddr, routes: Routes) -> Result<(), io::Error> {
-    let rdma = RdmaBuilder::default()
-        .set_max_message_length(MAX_MSG_LEN)
-        .listen(addr)
-        .await?;
-    let routes_clone = routes.clone();
-    rdma_serve_inner(&rdma, routes_clone).await?;
+async fn rdma_serve(addr: SocketAddr, routes: RdmaRoutes) -> Result<(), io::Error> {
+    let rdma = Arc::new(
+        RdmaBuilder::default()
+            .set_max_message_length(MAX_MSG_LEN)
+            .listen(addr)
+            .await?,
+    );
+    tokio::spawn(rdma_serve_inner(Arc::clone(&rdma), routes.clone()));
     loop {
-        let rdma = rdma.listen().await?;
+        let rdma = Arc::new(rdma.listen().await?);
         let routes = routes.clone();
-        tokio::spawn(async move { rdma_serve_inner(&rdma, routes).await });
+        tokio::spawn(rdma_serve_inner(rdma, routes.clone()));
     }
 }
 
 const MAX_MSG_LEN: usize = 10240;
 
 // TODO: handle this error
-async fn rdma_serve_inner(rdma: &Rdma, mut routes: Routes) -> Result<(), io::Error> {
+async fn rdma_serve_inner(rdma: Arc<Rdma>, mut routes: RdmaRoutes) -> Result<(), io::Error> {
     println!("[server] connected!");
 
     loop {
         let (req_mr, len) = rdma.receive_with_imm().await?;
         let len = len.unwrap() as usize;
-        let req_vec = req_mr.as_slice()[0..len].to_vec();
 
-        // deserialize
-        let idx = req_vec.iter().position(|num| *num == 32).unwrap();
-        let uri = &req_vec[0..idx];
-        let body = hyper::Body::from(req_vec[idx + 1..len].to_vec());
-        let req = http::Request::builder()
-            .method("POST")
-            .uri(uri)
-            .body(body)
+        let resp_mr = rdma.alloc_local_mr(Layout::new::<[u8; 1024]>()).unwrap();
+
+        let resp = routes
+            .call(RdmaRequest::new(req_mr, len, resp_mr))
+            .await
             .unwrap();
 
-        let mut resp = routes.call(req).await.unwrap();
-        let mut resp_mr = rdma
-            .alloc_local_mr(Layout::new::<[u8; MAX_MSG_LEN]>())
+        rdma.send_with_imm(&resp.resp_mr, resp.len as u32)
+            .await
             .unwrap();
-        let mut len = 0;
-        while let Some(Ok(bytes)) = resp.data().await {
-            let resp_body = bytes.to_vec();
-            let len_body = resp_body.len();
-            resp_mr.as_mut_slice()[len..len + len_body].copy_from_slice(resp_body.as_slice());
-            len += len_body;
-        }
-        rdma.send_with_imm(&resp_mr, len as u32).await.unwrap();
     }
     // Ok(())
 }

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -22,4 +22,4 @@ pub(crate) use self::io::ServerIo;
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;
 
-pub use self::router::Routes;
+pub use self::router::{RdmaRoutes, Routes};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Currently tonic only supports HTTP, so I tried to add optional RDMA communication feature.

Using RDMA(if machine supports) can improve communication efficiency.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

RDMA communication based on `async-rdma` crate. RDMA establishes a connection via TCP, then communicates using SEND/RECV operations.

Server handles both HTTP and RDMA requests through `serve_with_rdma`. This function listens to two TCP ports, which are used for HTTP and RDMA connection establishment respectively. 

Client has two options to communicate with the server: either HTTP via Channel(`connect`) or RDMA via RdmaChannel(`connect_rdma`).